### PR TITLE
Add chest connections

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -661,7 +661,16 @@ script.on_event(defines.events.on_tick, function(event)
 						end
 					elseif e6 then
 						dbg("Connecting chest")
-						local e = place_entity(surface, e6.name, pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                local e
+                                                if e6.name == "logistic-chest-requester" then
+                                                    e = place_entity(surface, "logistic-chest-active-provider", pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                elseif e6.name == "logistic-chest-active-provider" then
+                                                    e = place_entity(surface, "logistic-chest-requester", pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                elseif e6.name == "logistic-chest-passive-provider" then
+                                                    e = place_entity(surface, "logistic-chest-requester", pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                else
+						    e = place_entity(surface, e6.name, pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                end
 						if e then
 							structure.connections[id] = {from = e, to = e6, inside = e, outside = e6, conn_type = "chest", inv = {}}
 						end

--- a/control.lua
+++ b/control.lua
@@ -625,7 +625,7 @@ script.on_event(defines.events.on_tick, function(event)
 					local e4 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe"}[1]
 					local e5 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe-to-ground"}[1]
 					local e6 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="container"}[1] or parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="logistic-container"}[1]
-                                        e6 = (e6.name:sub(1,10) ~= "warehouse-" or e6.name:find("medium") or e6.name:find("big") or e6.name:sub(1,7) == "ammobox")) and e6 or nil --Disables most larger chests added by other mods from connecting with the factory
+                                        e6 = (e6.name:sub(1,10) ~= "warehouse-" and e6.name:find("medium") and e6.name:find("big") and e6.name:sub(1,7) == "ammobox") and e6.name ~= "robo-miner-logistic-chest-active-provider") and e6 or nil --Disables most larger chests added by other mods from connecting with the factory
 					if e3 then
 						if e3.direction == pconn.direction_in then
 							dbg("Connecting inwards belt")

--- a/control.lua
+++ b/control.lua
@@ -505,11 +505,11 @@ function transfer_items_chest(from, to, inv) -- from, to are inventories, inv is
 		total[t] = (total[t] or 0) + c
 	end
 	to.clear()
-	for t, c in pairs(from.get_contents()) do
+	for t, c in pairs(from.get_contents()) do 
 		total[t] = (total[t] or 0) + c
 	end
 	from.clear()
-	for t, c in pairs(inv) do
+	for t, c in pairs(inv) do --calculate the distance between the two chests and the previous total
 		total[t] = (total[t] or 0) - c
 	end
 	for t,c in pairs(total) do
@@ -625,7 +625,7 @@ script.on_event(defines.events.on_tick, function(event)
 					local e4 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe"}[1]
 					local e5 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe-to-ground"}[1]
 					local e6 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="container"}[1] or parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="logistic-container"}[1]
-                                        e6 = (e6.name:sub(1,10) ~= "warehouse-" or e6.name:find("medium") or e6.name:find("big")) and e6 or nil --Disables most larger chests added by other mods from connecting with the factory
+                                        e6 = (e6.name:sub(1,10) ~= "warehouse-" or e6.name:find("medium") or e6.name:find("big") or e6.name:sub(1,7) == "ammobox")) and e6 or nil --Disables most larger chests added by other mods from connecting with the factory
 					if e3 then
 						if e3.direction == pconn.direction_in then
 							dbg("Connecting inwards belt")

--- a/control.lua
+++ b/control.lua
@@ -663,7 +663,7 @@ script.on_event(defines.events.on_tick, function(event)
 						dbg("Connecting chest")
                                                 local e
                                                 if e6.name == "logistic-chest-requester" then
-                                                    e = place_entity(surface, "logistic-chest-active-provider", pconn.inside_x, pconn.inside_y, structure.parent.force)
+                                                    e = place_entity(surface, "logistic-chest-passive-provider", pconn.inside_x, pconn.inside_y, structure.parent.force)
                                                 elseif e6.name == "logistic-chest-active-provider" then
                                                     e = place_entity(surface, "logistic-chest-requester", pconn.inside_x, pconn.inside_y, structure.parent.force)
                                                 elseif e6.name == "logistic-chest-passive-provider" then

--- a/control.lua
+++ b/control.lua
@@ -625,6 +625,7 @@ script.on_event(defines.events.on_tick, function(event)
 					local e4 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe"}[1]
 					local e5 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe-to-ground"}[1]
 					local e6 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="container"}[1] or parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="logistic-container"}[1]
+                                        e6 = (e6.name:sub(1,10) ~= "warehouse-") and e6 or nil
 					if e3 then
 						if e3.direction == pconn.direction_in then
 							dbg("Connecting inwards belt")

--- a/control.lua
+++ b/control.lua
@@ -625,7 +625,7 @@ script.on_event(defines.events.on_tick, function(event)
 					local e4 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe"}[1]
 					local e5 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="pipe-to-ground"}[1]
 					local e6 = parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="container"}[1] or parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}, type="logistic-container"}[1]
-                                        e6 = (e6.name:sub(1,10) ~= "warehouse-") and e6 or nil
+                                        e6 = (e6.name:sub(1,10) ~= "warehouse-" or e6.name:find("medium") or e6.name:find("big")) and e6 or nil --Disables most larger chests added by other mods from connecting with the factory
 					if e3 then
 						if e3.direction == pconn.direction_in then
 							dbg("Connecting inwards belt")


### PR DESCRIPTION
Adds functionality to make chests connect from the outside of the factory building to the inside. No visible performance hit on my PC but it is very beefy so on a less powerful one it might be a problem. Feel free to test and if there are problems I can try to optimize it. I fixed all of the bugs that came up but I might have missed some. Also, requester chest slots don't link, I'm pretty sure it's possible but I didn't have a whole lot of time and I don't really think it would be worth the performance hit. The chests auto balance (more like they act as 1 chest - the contents are copied) but they don't keep the stack structure (5 stacks of 20 iron would combine into one stack of 100). I don't really think this matters but you might.
PS. I like your mod :)
