### PR TITLE
ADD connections with logistic chests

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
   "name": "Factorissimo",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "title": "Factorissimo",
   "author": "MagmaMcFry",
   "description": "Adds factory buildings you can walk into and build parts of your factory inside.",
-  "factorio_version": "0.14",
-  "dependencies": ["base >= 0.14.0"]
+  "factorio_version": "0.13",
+  "dependencies": ["base >= 0.13.0"]
 }


### PR DESCRIPTION
Hi there

I add new type of connections with logistic chests. 

If player sets the requester chest to outside port, inside the building creates a passive provider chests. Every tic requested items from RC moves to PPC until their count in PPC less then count requested.

If player sets some other logistic chest to outside port, inside creates a equals chest. Every tic items from inside chest moves to outside (if it's possible).

There is one problem that I didn't solve: multiplayer doesn't support: when one of the chests destroyed by player, all items from both chests moves to player 1

Also it's great to connect inside and outside chest to logistic network (e.g. when wire connects to inside chests, it connects to outside chest instead)
