### PR TITLE
Allow an unlimited(?) number of factories

### DIFF
--- a/connections.lua
+++ b/connections.lua
@@ -42,7 +42,7 @@ function update_pending_connections()
 	end
 end
 
-function test_for_connection(parent_surface, factory, interior, raw_specs, fx, fy)
+function test_for_connection(parent_surface, factory, interior, raw_specs, offset, fx, fy)
 	local px = fx + raw_specs.outside_x
 	local py = fy + raw_specs.outside_y
 	for _, outside_entity in pairs(parent_surface.find_entities_filtered{area = {{px-0.2, py-0.2},{px+0.2, py+0.2}}}) do
@@ -51,7 +51,7 @@ function test_for_connection(parent_surface, factory, interior, raw_specs, fx, f
 				local data = methods.accepts_outside_entity(
 					outside_entity, factory, interior, {
 						outside_pos = {x = px, y = py},
-						inside_pos = {x = raw_specs.inside_x, y = raw_specs.inside_y},
+						inside_pos = {x = raw_specs.inside_x + offset.tile_x, y = raw_specs.inside_y + offset.tile_y},
 						direction_in = raw_specs.direction_in,
 						direction_out = raw_specs.direction_out,
 					}

--- a/control.lua
+++ b/control.lua
@@ -418,7 +418,7 @@ local function check_connections(factory, surface, structure, layout, parent_sur
 				data = nil
 				structure.connections[id] = nil
 			end
-		elseif factory_placement_valid(surface, parent_surface) then
+		elseif factory_placement_valid(structure) then
 			local fx = structure.factory.position.x
 			local fy = structure.factory.position.y
 			structure.connections[id] = test_for_connection(parent_surface, factory, surface, pconn, structure.offset, fx, fy)
@@ -497,15 +497,19 @@ end)
 
 -- RECURSION
 
-function factory_placement_valid(inner_surface, outer_surface)
---	if is_factory(inner_surface) and is_factory(outer_surface) then
---		local inner_tier = get_layout(inner_surface).tier or 0
---		local outer_tier = get_layout(outer_surface).tier or 0
---		if factorissimo.config.recursion == 0 then return false end
---		if factorissimo.config.recursion == 1 then return inner_tier < outer_tier end
---		if factorissimo.config.recursion == 2 then return inner_tier <= outer_tier end
---		return true
---	end
+function factory_placement_valid(structure)
+	local inner_layout = get_structure_layout(structure)
+	local outer_layout = get_surface_layout(structure.factory.surface)
+
+	if inner_layout and outer_layout then
+		local inner_tier = inner_layout.tier or 0
+		local outer_tier = inner_layout.tier or 0
+		dbg("factory_placement_valid: inner=" .. inner_tier .. ", outer=" .. outer_tier)
+		if factorissimo.config.recursion == 0 then return false end
+		if factorissimo.config.recursion == 1 then return inner_tier < outer_tier end
+		if factorissimo.config.recursion == 2 then return inner_tier <= outer_tier end
+		return true
+	end
 	return true
 end
 
@@ -532,7 +536,7 @@ function try_enter_factory(player)
 	if factory and math.abs(factory.position.x-player.position.x) < 0.6 then
 		local structure = get_factory_structure(factory)
 		local new_surface = structure.surface
-		if structure.finished and factory_placement_valid(new_surface, factory.surface) then
+		if structure.finished and factory_placement_valid(structure) then
 			dbg("Entering structure: " .. structure.name)
 			reset_daytime(new_surface)
 			player.teleport({structure.entrance.x, structure.entrance.y}, new_surface)

--- a/control.lua
+++ b/control.lua
@@ -105,11 +105,14 @@ end
 
 function connect_factory_to_existing_structure(factory, structure)
 	local layout = get_structure_layout(structure)
+
+	structure.factory = factory
 	structure.exit = {
 		x = factory.position.x + layout.exit_x,
 		y = factory.position.y + layout.exit_y,
 		surface = factory.surface,
 	}
+
 	set_factory_structure(factory, structure)
 	dbg("reconnected " .. structure.name)
 end

--- a/control.lua
+++ b/control.lua
@@ -9,11 +9,12 @@ require("connections")
 -- GLOBALS --
 
 function glob_init()
-	global["factory-surface"] = global["factory-surface"] or {}
-	global["surface-structure"] = global["surface-structure"] or {}
-	global["surface-layout"] = global["surface-layout"] or {}
-	global["surface-exit"] = global["surface-exit"] or {}
 	global["health-data"] = global["health-data"] or {}
+
+	global["surfaces"] = global["surfaces"] or {}
+	global["structures"] = global["structures"] or {}
+	global["entity-structures"] = global["entity-structures"] or {}
+	global["factory-structures"] = global["entity-structures"] or {}
 	init_connection_structure()
 end
 
@@ -33,56 +34,151 @@ local DEBUG = false
 
 local LAYOUT = layouts()
 
+local CHUNK_SIZE = 64
+
 -- FACTORY WORLD ASSIGNMENT --
 
-function create_surface(factory, layout)
-	local surface_name = "Inside factory " .. factory.unit_number
-	local surface = game.create_surface(surface_name, {width = 64*layout.chunk_radius-62, height = 64*layout.chunk_radius-62})
-	surface.request_to_generate_chunks({0, 0}, layout.chunk_radius)
-	global["factory-surface"][factory.unit_number] = surface -- surface_name
-	global["surface-structure"][surface_name] = {parent = factory, ticks = 0, connections = {}, chunks_generated = 0, chunks_required = 4*layout.chunk_radius*layout.chunk_radius, finished = false}
-	global["surface-layout"][surface_name] = layout.name
-	global["surface-exit"][surface_name] = {x = factory.position.x+layout.exit_x, y = factory.position.y+layout.exit_y, surface = factory.surface}
+function maybe_create_surface(layout)
+	local name = "factorissimo " .. layout.name
+	local surface = game.surfaces[name]
+	if surface then
+		return surface
+	else
+		return create_surface(layout, name)
+	end
+end
+
+function create_surface(layout, surface_name)
+	local surface = game.create_surface(surface_name, {
+		width = 2,
+		height = 2,
+	})
+
+	global["surfaces"][surface_name] = {
+		layout_name = layout.name,
+		chunks_generated = 0,
+		chunks_required = 4, -- based on width+height above
+		chunks_finished = false
+	}
+
+	surface.request_to_generate_chunks({0, 0}, 1)
 	reset_daytime(surface)
+	return surface
+end
+
+function create_structure(factory, layout, surface)
+	local structure_index = next_structure_index(layout)
+	local structure_name = layout.name .. "_" .. structure_index
+	dbg("creating " .. structure_name)
+	local offset = calculate_offset(layout, structure_index)
+
+	local structure = {
+		name = structure_name,
+		layout_name = layout.name,
+		index = structure_index,
+		factory = factory,
+		surface = surface,
+		surface_details = get_surface_details(surface),
+		ticks = 0,
+		connections = {},
+		finished = false,
+
+		offset = offset,
+		exit = {
+			x = factory.position.x+layout.exit_x,
+			y = factory.position.y+layout.exit_y,
+			surface = factory.surface,
+		},
+		entrance = {
+			x = layout.entrance_x + offset.tile_x,
+			y = layout.entrance_y + offset.tile_y,
+			surface = surface,
+		},
+	}
+	global["structures"][structure_name] = structure
+	set_factory_structure(factory, structure)
 end
 
 function connect_factory_to_existing_surface(factory, surface)
 	global["factory-surface"][factory.unit_number] = surface
-	global["surface-structure"][surface.name].parent = factory
+	global["surface-structure"][surface.name].factory = factory
 	local layout = get_layout(surface)
 	global["surface-exit"][surface.name] = {x = factory.position.x+layout.exit_x, y = factory.position.y+layout.exit_y, surface = factory.surface}
 end
 
-function has_surface(factory)
-	return global["factory-surface"][factory.unit_number] ~= nil
+-- If this function gets slow, it should probably start using
+-- global sequence numbers and just incrementing them.
+-- Might want to change the name to claim_next_structure_index at that point.
+--
+-- On the other hand, by the time this starts getting slow, the per-tick
+-- code will probably need optimisation anyway.  And this is run rarely.
+function next_structure_index(layout)
+	max_index = 0
+	for structure_name, structure in pairs(get_all_structures()) do
+		if structure.layout_name == layout.name and structure.index > max_index then
+			max_index = structure.index
+		end
+	end
+	dbg("max structure index for " .. layout.name .. ": " .. max_index)
+	return max_index + 1
 end
 
-function get_surface(factory)
-	return global["factory-surface"][factory.unit_number]
+function calculate_offset(layout, index)
+	-- Initial offsets are linear, left to right.
+	-- TODO: Use either modulo-eight compass bearings,
+	--       or a square-/root-based X+Y system.
+	local chunk_x = (index - 1) * layout.chunk_radius * 4
+	local chunk_y = 0
+	dbg("offset: x = " .. chunk_x .. ", y = " .. chunk_y)
+	return {
+		chunk_x = chunk_x,
+		chunk_y = chunk_y,
+		tile_x = CHUNK_SIZE * chunk_x,
+		tile_y = CHUNK_SIZE * chunk_y,
+	}
 end
 
-function is_factory(surface)
-	return global["surface-structure"][surface.name] ~= nil
+--function has_surface(factory)
+--	return global["factory-surface"][factory.unit_number] ~= nil
+--end
+
+function is_factory_surface(surface)
+	return global["surfaces"][surface.name] ~= nil
 end
 
-function get_structure(surface)
-	return global["surface-structure"][surface.name]
+function get_factory_structure(factory)
+	return global["factory-structures"][factory.unit_number]
+end
+function set_factory_structure(factory, structure)
+	global["factory-structures"][factory.unit_number] = structure
 end
 
-function set_structure(surface, structure_id, entity)
-	global["surface-structure"][surface.name][structure_id] = entity
+function get_entity_structure(entity)
+	return global["entity-structures"][entity.unit_number]
+end
+function set_entity_structure(entity, structure)
+	global["entity-structures"][entity.unit_number] = structure
 end
 
 function get_all_structures()
-	return global["surface-structure"]
+	return global["structures"]
 end
 
-function get_layout(surface)
-	if global["surface-layout"][surface.name] then
-		return LAYOUT[global["surface-layout"][surface.name]]
+function get_surface_details(surface)
+	return global["surfaces"][surface.name]
+end
+
+function get_surface_layout(surface)
+	local surface_details = get_surface_details(surface)
+	if surface_details then
+		return LAYOUT[surface_details.layout_name]
 	else
 		return nil
 	end
+end
+
+function get_structure_layout(structure)
+	return LAYOUT[structure.surface_details.layout_name]
 end
 
 function get_layout_by_name(surface_name)
@@ -91,10 +187,6 @@ function get_layout_by_name(surface_name)
 	else
 		return nil
 	end
-end
-
-function get_exit(surface)
-	return global["surface-exit"][surface.name]
 end
 
 function save_health_data(factory)
@@ -135,7 +227,7 @@ end
 -- Daytime values: 0 is eternal night, 1 is regular, 2 is eternal day
 function reset_daytime(surface)
 	local daytime = 0
-	local layout = get_layout(surface)
+	local layout = get_surface_layout(surface)
 	if not layout then return end
 	if layout.is_power_plant then
 		daytime = factorissimo.config.power_plant_daytime
@@ -154,18 +246,15 @@ function reset_daytime(surface)
 	end
 end
 
-function delete_entities(surface)
-	for _, entity in pairs(surface.find_entities({{-1000, -1000},{1000, 1000}})) do
-		entity.destroy()
-	end
-end
-
-function add_tile_rect(tiles, tile_name, xmin, ymin, xmax, ymax) -- tiles is rw
+function add_tile_rect(tiles, tile_name, xmin, ymin, xmax, ymax, offset) -- tiles is rw
 	local i = #tiles
 	for x = xmin, xmax-1 do
 		for y = ymin, ymax-1 do
 			i = i + 1
-			tiles[i] = {name = tile_name, position={x, y}}
+			tiles[i] = {name = tile_name, position = {
+				x + offset.tile_x,
+				y + offset.tile_y,
+			}}
 		end
 	end
 end
@@ -182,45 +271,68 @@ end
 
 
 -- TODO merge with place_entity?
-function place_entity_generated(surface, entity_name, x, y, structure_id)
-	entity = surface.create_entity{name = entity_name, position = {x, y}, force = get_structure(surface).parent.force}
+function place_entity_generated(structure, entity_name, x, y, structure_key)
+	local surface = structure.surface
+	local entity = surface.create_entity{
+		name = entity_name,
+		position = {
+			x + structure.offset.tile_x,
+			y + structure.offset.tile_y,
+		},
+		force = structure.factory.force,
+	}
 	if entity then
 		entity.minable = false
 		entity.rotatable = false
 		entity.destructible = false
-		if structure_id and entity then
-			dbg("Placed and registered " .. structure_id)
-			set_structure(surface, structure_id, entity)
+		if structure_key and entity then
+			dbg("Placed and registered " .. structure_key)
+			structure[structure_key] = entity
 		end
 	end
+	return entity
 end
 
-function build_factory_interior(factory, surface, layout, structure)
-	delete_entities(surface)
+function build_factory_interior(structure)
+	dbg("build_factory_interior")
+	local surface = structure.surface
+	local layout = get_structure_layout(structure)
+
 	tiles = {}
 	for _, pconn in pairs(layout.possible_connections) do
-		add_tile_rect(tiles, "factory-wall", pconn.inside_x-1, pconn.inside_y-1, pconn.inside_x+2, pconn.inside_y+2)
+		add_tile_rect(tiles, "factory-wall", pconn.inside_x-1, pconn.inside_y-1, pconn.inside_x+2, pconn.inside_y+2, structure.offset)
 	end
 	for _, rect in pairs(layout.rectangles) do
-		add_tile_rect(tiles, rect.tile, rect.x1, rect.y1, rect.x2, rect.y2)
+		add_tile_rect(tiles, rect.tile, rect.x1, rect.y1, rect.x2, rect.y2, structure.offset)
 	end
 	for _, pconn in pairs(layout.possible_connections) do
-		add_tile_rect(tiles, "factory-entrance", pconn.inside_x, pconn.inside_y, pconn.inside_x+1, pconn.inside_y+1)
+		add_tile_rect(tiles, "factory-entrance", pconn.inside_x, pconn.inside_y, pconn.inside_x+1, pconn.inside_y+1, structure.offset)
 	end
 	surface.set_tiles(tiles)
 	if layout.is_power_plant then
-		place_entity_generated(surface, "factory-power-receiver", layout.provider_x, layout.provider_y, "power_provider")
+		place_entity_generated(structure, "factory-power-receiver", layout.provider_x, layout.provider_y, "power_provider")
 	else
-		place_entity_generated(surface, "factory-power-provider", layout.provider_x, layout.provider_y, "power_provider")
+		place_entity_generated(structure, "factory-power-provider", layout.provider_x, layout.provider_y, "power_provider")
 	end
-	place_entity_generated(surface, "factory-power-distributor", layout.distributor_x, layout.distributor_y)
+
+	-- We use this for the exit, so we register it in a lookup table.
+	-- TODO: Maybe create an exit sign and use that instead?
+	local distributor = place_entity_generated(structure, "factory-power-distributor", layout.distributor_x, layout.distributor_y)
+	set_entity_structure(distributor, structure)
+
 	structure.finished = true
 end
 
 script.on_event(defines.events.on_chunk_generated, function(event)
-	if is_factory(event.surface) then
-		local structure = get_structure(event.surface)
-		structure.chunks_generated = structure.chunks_generated + 1 -- Wait until all chunks are generated and then some, to avoid other mods' worldgen interfering
+	local details = get_surface_details(event.surface)
+	if details and not details.chunks_finished then
+		-- Wait until all chunks are generated and then some, to avoid other mods' worldgen interfering
+		details.chunks_generated = details.chunks_generated + 1
+		dbg("chunks generated: " .. details.chunks_generated)
+		if details.chunks_generated >= details.chunks_required then
+			details.chunks_finished = true
+			dbg("chunks finished!")
+		end
 	end
 end)
 
@@ -239,10 +351,11 @@ function on_built_factory(factory)
 		end
 		mark_connections_dirty(factory)
 
-	elseif not has_surface(factory) then -- Should always be the case, but just in case
+	else
 		dbg("Generating new factory interior")
 		local layout = LAYOUT[factory.name]
-		create_surface(factory, layout)
+		local surface = maybe_create_surface(factory, layout)
+		create_structure(factory, layout, surface)
 		factory.energy = 0
 	end
 end
@@ -274,9 +387,9 @@ script.on_event({defines.events.on_built_entity, defines.events.on_robot_built_e
 		-- Entity needs to update factory connections
 		local entities = entity.surface.find_entities_filtered{area = {{entity.position.x-5, entity.position.y-5},{entity.position.x+5, entity.position.y+5}}} -- Generous search radius, maybe too generous
 		for _, entity2 in pairs(entities) do
-			if has_surface(entity2) then
-				-- entity2 is factory
-				mark_connections_dirty(entity2)
+			local structure = get_factory_structure(entity2)
+			if structure then
+				mark_structure_connections_dirty(structure)
 			end
 		end
 	end
@@ -309,11 +422,7 @@ function balance_power(from, to, multiplier)
 	to.energy = to.energy + max_transfer_energy * multiplier
 end
 
-function mark_connections_dirty(factory)
-	local surface = get_surface(factory)
-	if not surface then return end
-	local structure = get_structure(surface)
-	if not structure then return end
+function mark_structure_connections_dirty(structure)
 	structure.connections_dirty = true
 end
 
@@ -329,11 +438,10 @@ local function check_connections(factory, surface, structure, layout, parent_sur
 				data = nil
 				structure.connections[id] = nil
 			end
-		end
-		if data == nil and factory_placement_valid(surface, parent_surface) then
-			local fx = structure.parent.position.x
-			local fy = structure.parent.position.y
-			structure.connections[id] = test_for_connection(parent_surface, factory, surface, pconn, fx, fy)
+		elseif factory_placement_valid(surface, parent_surface) then
+			local fx = structure.factory.position.x
+			local fy = structure.factory.position.y
+			structure.connections[id] = test_for_connection(parent_surface, factory, surface, pconn, structure.offset, fx, fy)
 		end
 	end
 end
@@ -351,27 +459,29 @@ script.on_event(defines.events.on_tick, function(event)
 	update_pending_connections()
 
 	-- BASE FACTORY MECHANICS
-	for surface_name, structure in pairs(get_all_structures()) do
-		if structure.parent and structure.parent.valid and structure.finished then -- Don't do anything before the interior has finished generating
+	for structure_name, structure in pairs(get_all_structures()) do
+		if not (structure.factory and structure.factory.valid) then
+			-- skip it
+		elseif structure.finished then -- Don't do anything before the interior has finished generating
 		
 			structure.ticks = (structure.ticks or 0) + 1
 		
-			local surface = get_surface(structure.parent) --game.surfaces[surface_name]
-			local parent_surface = structure.parent.surface
-			local layout = get_layout(surface)
+			local surface = structure.surface
+			local parent_surface = structure.factory.surface
+			local layout = get_structure_layout(structure)
 			
 			-- TRANSFER POWER
 			if structure.power_provider and structure.power_provider.valid then
 				if layout.is_power_plant then
-					balance_power(structure.power_provider, structure.parent, factorissimo.config.power_output_multiplier)
+					balance_power(structure.power_provider, structure.factory, factorissimo.config.power_output_multiplier)
 				else
-					balance_power(structure.parent, structure.power_provider, factorissimo.config.power_input_multiplier)
+					balance_power(structure.factory, structure.power_provider, factorissimo.config.power_input_multiplier)
 				end
 			end
 			
 			-- TRANSFER POLLUTION
 			if structure.ticks % 60 < 1 then
-				local exit_pos = get_exit(surface) 
+				local exit_pos = structure.exit
 				for y = -1,1,2 do
 					for x = -1,1,2 do
 						local pollution = surface.get_pollution({x, y})
@@ -384,17 +494,18 @@ script.on_event(defines.events.on_tick, function(event)
 			-- CHECK FOR NEW CONNECTIONS
 			if structure.connections_dirty then
 				structure.connections_dirty = false
-				check_connections(structure.parent, surface, structure, layout, parent_surface)
+				check_connections(structure.factory, surface, structure, layout, parent_surface)
 			end
-		elseif structure.parent and structure.parent.valid and structure.chunks_generated == structure.chunks_required then
-			-- We need to wait until the factory interior surface is generated with default worldgen, then replace it with our own interior
-			local surface = get_surface(structure.parent)
-			local layout = get_layout(surface)
-			build_factory_interior(structure.parent, surface, layout, structure)
+		elseif not structure.surface_details.chunks_finished then
+			-- Don't do anything until the global surface has finished default worldgen.
+			-- Should only happen for the first factory of each layout.
+		else
+			-- Create the interior for our structure
+			build_factory_interior(structure)
 			-- This can theoretically be called repeatedly each tick until the factory is marked finished
 			if structure.finished then
 				-- Check connections once the factory is finished
-				mark_connections_dirty(structure.parent)
+				mark_structure_connections_dirty(structure)
 			end
 		end
 	end
@@ -403,14 +514,14 @@ end)
 -- RECURSION
 
 function factory_placement_valid(inner_surface, outer_surface)
-	if is_factory(inner_surface) and is_factory(outer_surface) then
-		local inner_tier = get_layout(inner_surface).tier or 0
-		local outer_tier = get_layout(outer_surface).tier or 0
-		if factorissimo.config.recursion == 0 then return false end
-		if factorissimo.config.recursion == 1 then return inner_tier < outer_tier end
-		if factorissimo.config.recursion == 2 then return inner_tier <= outer_tier end
-		return true
-	end
+--	if is_factory(inner_surface) and is_factory(outer_surface) then
+--		local inner_tier = get_layout(inner_surface).tier or 0
+--		local outer_tier = get_layout(outer_surface).tier or 0
+--		if factorissimo.config.recursion == 0 then return false end
+--		if factorissimo.config.recursion == 1 then return inner_tier < outer_tier end
+--		if factorissimo.config.recursion == 2 then return inner_tier <= outer_tier end
+--		return true
+--	end
 	return true
 end
 
@@ -435,25 +546,24 @@ end
 function try_enter_factory(player)
 	local factory = get_factory_beneath(player)
 	if factory and math.abs(factory.position.x-player.position.x) < 0.6 then
-		local new_surface = get_surface(factory)
-		if new_surface and factory_placement_valid(new_surface, factory.surface) then
-			local structure = get_structure(new_surface)
-				if structure.finished then
-					local layout = get_layout(new_surface)
-					reset_daytime(new_surface)
-					player.teleport({layout.entrance_x, layout.entrance_y}, new_surface)
-					return
-				end
+		local structure = get_factory_structure(factory)
+		local new_surface = structure.surface
+		if structure.finished and factory_placement_valid(new_surface, factory.surface) then
+			dbg("Entering structure: " .. structure.name)
+			reset_daytime(new_surface)
+			player.teleport({structure.entrance.x, structure.entrance.y}, new_surface)
+			return
 		end
 	end
 end
 
 function try_leave_factory(player)
-	local exit_building = get_exit_beneath(player)
-	if exit_building then
-		local exit_pos = get_exit(player.surface)
-		if exit_pos then
-			player.teleport({exit_pos.x, exit_pos.y}, exit_pos.surface)
+	local exit_entity = get_exit_beneath(player)
+	if exit_entity then
+		local structure = get_entity_structure(exit_entity)
+		if structure then
+			dbg("Exiting structure: " .. structure.name)
+			player.teleport({structure.exit.x, structure.exit.y}, structure.exit.surface)
 			return
 		end
 	end

--- a/control.lua
+++ b/control.lua
@@ -12,6 +12,8 @@ function glob_init()
 	global["health-data"] = global["health-data"] or {}
 
 	global["surfaces"] = global["surfaces"] or {}
+	global["layout-surfaces"] = global["layout-surfaces"] or {}
+
 	global["structures"] = global["structures"] or {}
 	global["entity-structures"] = global["entity-structures"] or {}
 	global["factory-structures"] = global["entity-structures"] or {}
@@ -39,12 +41,11 @@ local CHUNK_SIZE = 64
 -- FACTORY WORLD ASSIGNMENT --
 
 function maybe_create_surface(layout)
-	local name = "factorissimo " .. layout.name
-	local surface = game.surfaces[name]
-	if surface then
-		return surface
+	local details = global["layout-surfaces"][layout.name]
+	if details then
+		return details.surface
 	else
-		return create_surface(layout, name)
+		return create_surface(layout, "Factorissimo " .. layout.name)
 	end
 end
 
@@ -54,12 +55,15 @@ function create_surface(layout, surface_name)
 		height = 2,
 	})
 
-	global["surfaces"][surface_name] = {
+	local details = {
+		surface = surface,
 		layout_name = layout.name,
 		chunks_generated = 0,
 		chunks_required = 4, -- based on width+height above
 		chunks_finished = false
 	}
+	global["surfaces"][surface_name] = details
+	global["layout-surfaces"][layout.name] = details
 
 	surface.request_to_generate_chunks({0, 0}, 1)
 	reset_daytime(surface)

--- a/control.lua
+++ b/control.lua
@@ -146,14 +146,6 @@ function calculate_offset(layout, index)
 	}
 end
 
---function has_surface(factory)
---	return global["factory-surface"][factory.unit_number] ~= nil
---end
-
-function is_factory_surface(surface)
-	return global["surfaces"][surface.name] ~= nil
-end
-
 function get_factory_structure(factory)
 	return global["factory-structures"][factory.unit_number]
 end
@@ -187,14 +179,6 @@ end
 
 function get_structure_layout(structure)
 	return LAYOUT[structure.surface_details.layout_name]
-end
-
-function get_layout_by_name(surface_name)
-	if global["surface-layout"][surface_name] then
-		return LAYOUT[global["surface-layout"][surface_name]]
-	else
-		return nil
-	end
 end
 
 function save_health_data(factory, structure)
@@ -267,18 +251,6 @@ function add_tile_rect(tiles, tile_name, xmin, ymin, xmax, ymax, offset) -- tile
 	end
 end
 
-function place_entity(surface, entity_name, x, y, force, direction)
-	entity = surface.create_entity{name = entity_name, position = {x, y}, force = force, direction = direction}
-	if entity then
-		entity.minable = false
-		entity.rotatable = false
-		entity.destructible = false
-	end
-	return entity
-end
-
-
--- TODO merge with place_entity?
 function place_entity_generated(structure, entity_name, x, y, structure_key)
 	local surface = structure.surface
 	local entity = surface.create_entity{

--- a/control.lua
+++ b/control.lua
@@ -89,8 +89,8 @@ function create_structure(factory, layout, surface)
 
 		offset = offset,
 		exit = {
-			x = factory.position.x+layout.exit_x,
-			y = factory.position.y+layout.exit_y,
+			x = factory.position.x + layout.exit_x,
+			y = factory.position.y + layout.exit_y,
 			surface = factory.surface,
 		},
 		entrance = {
@@ -484,13 +484,17 @@ script.on_event(defines.events.on_tick, function(event)
 			end
 			
 			-- TRANSFER POLLUTION
+			-- TODO: This assumes there are only four core squares we care about, centred around {0,0}, plus the factory interior offset.
+		        -- It should instead ask for the pollution of every chunk, using the layout.chunk_radius.
 			if structure.ticks % 60 < 1 then
-				local exit_pos = structure.exit
+				local exit = structure.exit
 				for y = -1,1,2 do
 					for x = -1,1,2 do
-						local pollution = surface.get_pollution({x, y})
-						surface.pollute({x, y}, -pollution/2)
-						parent_surface.pollute({exit_pos.x, exit_pos.y}, (pollution/2) * factorissimo.config.pollution_multiplier)
+						local offx = x + structure.offset.tile_x
+						local offy = y + structure.offset.tile_y
+						local pollution = surface.get_pollution({offx, offy})
+						surface.pollute({offx, offy}, -pollution/2)
+						exit.surface.pollute({exit.x, exit.y}, (pollution/2) * factorissimo.config.pollution_multiplier)
 					end
 				end
 			end


### PR DESCRIPTION
[Don't merge this, it'll break saves!  See below.]

I got about 90% of the way through this and then I heard that you're doing a version 2 rewrite, so I don't expect this'll be super useful to you, but I figured maybe some of the concepts and designs might help in your rewrite. :)

As far as I can tell/test, this is a fully working and feature-complete rewrite of the `control.lua` code (with one very minor tweak to `connections.lua`) to allow for infinite Factorissimo factories, subject only to world size limitations rather than number-of-surface limitations.

It achieves this by putting all factories of a particular layout onto a single surface, with increasingly distant X/Y offsets for each.  As such, most of the internal mappings had to change, since they treated the surface as the core identifier for a factory; obviously, this can no longer be the case.

`structure` is the new core object for anything, most things just link to that, and a lot of code has been changed to just pass around `structure` objects and glean all linked data (surfaces, entrances/exits, etc.) from that.  There's also a (perhaps badly named) "surface details" object (stored in `global["surfaces"]`) that keeps track of things like initial chunk generation, since that's no longer a per-structure thing.

Since most important data is now in the `structure` or `surface_details` objects, the only remaining globals are just additional ways to look up those objects:

* `global["layout-surfaces"]` — surface details by layout
  * this is just to avoid looking up surfaces by name (and thus depending on a single immutable surface naming scheme)
* `global["entity-structures"]` — structures by entity
  * the only thing I store here are the power distributors, so we can figure out what factory they're trying to exit from, since the surface no longer tells us
  * my personal suggestion would be to replace this dependency with an actual "exit sign" object — it can look nice and serve a purpose at the same time
* `global["factory-structures"]` — structures by factory entity
  * used for `try_enter_factory`
  * I briefly just stored these in `entity-structures`, but then I realised that would mean we'd mark connections as dirty if you built too close to the power distributor

I managed to avoid the need to come up with a "what structure is the player in?" function, because even `factory_placement_valid` only needs to know the layout tier numbers — and since there's one surface per layout, we can skip looking up structures and just jump straight to the layout objects.

So far, I haven't found any bugs re: putting multiple factories in a single surface. I'm way outside the world boundaries, but the game doesn't seem to care.  Thankfully, `set_tiles` is additive (i.e. it doesn't replace any previously-set tiles) and other per-chunk things (e.g. pollution) seem to be tracked just fine.  (I had to get rid of the "delete all entities in the entire surface" code, for obvious reasons.)

So, having tested this, here's what I've found:

**Advantages:**

* Infinite factories!
  * … in theory, at least.
    * I imagine it's subject to whatever world-size limitations Factorio might already have, plus RAM/disk etc.
    * Might also get slow evetually. :)
  * I've created over 500 in a test/cheat save without any problem.
  * They're separated by enough space that you can't see your neighbours even at max zoom, nor can you get power from them.
  * Connections, power, pollution, dismantling factories, etc. all seem to work perfectly.
  * Day/night settings work fine because power plants and factories are different layouts on different surfaces.
* Less work to create factories, since the surfaces only need to be created once.
  * No need to wait for chunk generation after the first factory of each layout.

**Disadvantages:**

* Maps (mini/full) are broken for all factories except the first.
  * Presumably, Factorio just refuses to map things outside the official world boundaries, even if you put tiles there.
  * Maybe there's a way to override that via API calls, but I haven't found it.
  * Seems pretty minor to me.  The only things the map might tell you:
    * Where everything is — but you can see the whole factory interior at once.
    * What the indoor pollution is — but it's very rapidly moved outside anyway.
  * Ideally, I'd love to make the world unbounded and just make it use a custom generator, if that's possible.
* Out to a certain distance, you can still see the first factory (of each layout) on the map/minimap.
  * … but not on the local view, even fully zoomed out.
  * I think this is an acceptable tradeoff.
  * If not, we can always just increase factory spacing, or just have a one-time spacing jump after the first factory (since you can't see the others on the map anyway).

**Other/todo:**

* Totally incompatible with previous saves! (in its current form)
  * I was originally hoping I could just make this behaviour a config flag, but the dramatic data restructuring quickly made that unfeasible.
  * I *think* we store enough data, independently and explicitly, that we could make this work via a migration.
    * We create new factories on the surface for that layout, but since each structure explicitly states its surface/entrance/etc (instead of inheriting that from layout), it *should* be possible to continue to support already-built factories on separate surfaces.
  * I'm happy to write it if you actually decide you want to merge this.
* There's a bit of data redundancy, e.g. we store the factory's surface in both `structure.surface` and in `structure.entrance.surface`.
  * Could be cleaned up if that's a concern.
* The separation between factories is hardcoded as `layout.chunk_radius * 4`
  * Should probably be a config variable.
  * I'd also maybe like to do some better math to make it spread factories out in all directions from `{x=0, y=0}`, rather than just extending in a straight line along the positive `x` axis.  Just seems cleaner, and might be more efficient.

Anyway, hope this gives you some ideas.  If you do actually want to merge this, let me know and I can fill in the missing bits, like seeing if we can retain save compatibility.  Otherwise, I hope this maybe gives you some ideas for version 2, if you haven't already done this. :)

I'll be using my own version for my own playthrough, and I'll update this if I find any bugs in my new code.
